### PR TITLE
fast versioning fix of Minecraft

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,14 +6,14 @@ org.gradle.parallel=true
 # check these on https://fabricmc.net/develop
 min_minecraft_version=1.21
 max_minecraft_version=1.21.1
-minecraft_versions=1.21,1.12.1
+minecraft_versions=1.21,1.21.1
 
 minecraft_version=1.21.1
 yarn_mappings=1.21.1+build.3
 loader_version=0.16.14
 
 # Mod Properties
-mod_version=1.2.4.7+1.21-1.21.1
+mod_version=1.2.4.7a+1.21-1.21.1
 maven_group=one.oth3r
 file_name=sit!
 


### PR DESCRIPTION
fix of the tags from minecraft versions vfrom 1.12.1 to 1.21.1 because thats also an issue since 1.2.3